### PR TITLE
Updated kotlin to 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.0.4'
+    ext.kotlin_version = '1.1.0'
 
     repositories {
         jcenter()


### PR DESCRIPTION
To keep the library updated and to avoid version conflicts.

Although they can be avoided also by excluding the kotlin-stdlib

    testCompile ('net.wuerl.kotlin:assertj-core-kotlin:0.1.3') {
        exclude module: 'kotlin-stdlib'
    }